### PR TITLE
Make three.js a peer dependency and require 0.86.0 as minimum version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.6",
   "description": "A module for using THREE.TrackballControls with nodejs",
   "main": "index.js",
-  "dependencies": {
-    "three": "^0.87.1"
+  "peerDependencies": {
+    "three": "^0.86.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Version 0.86 aligns with the minimum requirement as tagged from the most recent
commit [1] merged into three-trackballcontrols via MR #4 [2].

[1] https://github.com/mrdoob/three.js/commit/b110b162d8ede68ea0d0d200118ba4351e4a54d2
[2] https://github.com/JonLim/three-trackballcontrols/pull/4

I think it is feasable to make three.js a peer dependency, since who uses it will have
three.js already installed anyway.