### PR TITLE
Three.js dependency less strict

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "three-trackballcontrols",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "A module for using THREE.TrackballControls with nodejs",
   "main": "index.js",
   "peerDependencies": {
-    "three": "^0.86.0"
+    "three": ">= 0.86 <= 1.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
This library can work with multiple three.js versions so there is no need to restrict versions unless breaking changes will be introduced.

I want to propose to make peerDependency more flexible so developer can decide which version should be used. Strict version conflicts with other three.js libs which have their own peerDependencies.

#10 